### PR TITLE
Potential fix for code scanning alert no. 1: Type confusion through parameter tampering

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -71,7 +71,7 @@ app.post(API_ENDPOINTS.UPLOAD, upload.array('audio'), (req, res) => {
   try {
     const files = req.files as Express.Multer.File[];
 
-    if (!files || files.length === 0) {
+    if (!Array.isArray(files) || files.length === 0) {
       return res
         .status(HTTP_STATUS.BAD_REQUEST)
         .json(createApiResponse(false, null, 'No files uploaded'));


### PR DESCRIPTION
Potential fix for [https://github.com/jonahkeegan/critgenius-listener/security/code-scanning/1](https://github.com/jonahkeegan/critgenius-listener/security/code-scanning/1)

To fix the problem, we need to ensure that `files` is actually an array before using array methods like `map`, `reduce`, and accessing `length`. The best way to do this is to add a runtime type check using `Array.isArray(files)` before proceeding with the file processing logic. If `files` is not an array, we should return a 400 Bad Request response with an appropriate error message. This change should be made in the audio upload endpoint handler, specifically before any array operations are performed on `files` (i.e., before line 74). No new imports are needed, as `Array.isArray` is a built-in JavaScript method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
